### PR TITLE
Fix resolution of GET tile endpoint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -107,14 +107,14 @@ fn start_game(games: State<Games>, uuid: UUID) -> Option<Json<GameDescription>> 
     all.get(&uuid.uuid).map(|game| Json(game.description.clone()))    
 }
 
-#[get("/game/<uuid>/<name>")]
+#[get("/game/<uuid>/<name>", rank=2)]
 fn get_player(games: State<Games>, uuid: UUID, name: String) -> Option<Json<Player>> {
     games.lock().unwrap().get(&uuid.uuid).map(|game| {
         game.players.iter().find(|p| p.name == name).map(|p| Json(p.clone()))
     }).flatten()
 }
 
-#[get("/game/<uuid>/tile", rank=1)]
+#[get("/game/<uuid>/tile")]
 fn get_tile(games: State<Games>, uuid: UUID) -> Option<Json<Tile>> {
     let mut tile: Option<Tile> = None;
     with_game(games, uuid, |game| {


### PR DESCRIPTION
Fixes `GET /game/{UUID}/tile`. Rocket randomly assigns default ranks in the range of `-1` to `-6`. It gives precedence to _lower_ numbers. Using a value of `1` for `/tile` meant that it was always given lowest precedence. Opted to assign `rank=2` (instead of `rank=1`) for `/<player>` to more clearly communicate that it's the lower rank.