### PR TITLE
Add endpoints to get and set map tiles

### DIFF
--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -5,16 +5,35 @@ set -e
 SVR=${SVR-https://ecs.eddsteel.com}
 CRL="curl -s"
 
+echo "Create a game"
 id=$($CRL -X POST $SVR/game | jq -r .id)
+echo "$id"
 
 $CRL $SVR/game/$id | jq .
 
-$CRL -X PUT $SVR/game/$id?player=alice
-$CRL -X PUT $SVR/game/$id?player=bob
-$CRL -X PUT $SVR/game/$id?player=charles
+echo "Join the game"
+$CRL -X PUT $SVR/game/$id?player=alice | jq .
+$CRL -X PUT $SVR/game/$id?player=bob | jq .
+$CRL -X PUT $SVR/game/$id?player=charles | jq .
 
+echo "Check who's in the game"
 $CRL $SVR/game/$id | jq .
 
-$CRL -X PUT $SVR/game/$id/start
+echo "Start the game"
+$CRL -X PUT $SVR/game/$id/start | jq .
 
+echo "Check the game state"
 $CRL $SVR/game/$id | jq .
+
+echo "Get a tile"
+TILE=$($CRL $SVR/game/$id/tile)
+echo "$TILE" | jq .
+
+echo "Check for missing map tile"
+$CRL $SVR/game/$id/tiles/3/5 | jq .
+
+echo "Place a tile on the map"
+$CRL -X PUT $SVR/game/$id/tiles/3/5 --data "$($CRL $SVR/game/$id/tile | jq .)" | jq .
+
+echo "Check the tile was placed"
+$CRL $SVR/game/$id/tiles/3/5 | jq .

--- a/src/api.rs
+++ b/src/api.rs
@@ -73,7 +73,7 @@ impl Player {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Tile {
     pub id: u32,
     pub image: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,12 +115,30 @@ fn get_player(games: State<Games>, uuid: UUID, name: String) -> Option<Json<Play
 }
 
 #[get("/game/<uuid>/tile", rank=1)]
-fn get_tile(games: State<Games>, uuid: UUID) -> Option<Json<Tile>> {
+fn get_next_tile(games: State<Games>, uuid: UUID) -> Option<Json<Tile>> {
     let mut tile: Option<Tile> = None;
     with_game(games, uuid, |game| {
         tile = game.pop_tile()
     });
     tile.map(|t| Json(t))
+}
+
+#[get("/game/<uuid>/tiles/<x>/<y>")]
+fn get_tile(games: State<Games>, uuid: UUID, x: i8, y: i8) -> Option<Option<Json<Tile>>> {
+    let mut tile: Option<Option<Tile>> = None;
+    with_game(games, uuid, |game| {
+        tile = Some(game.get_tile(x, y));
+    });
+    // TODO(toby): This always results in a 404 if the tile is missing. Should be 200 with some result as long as the game ID is valid.
+    tile.map(|t| t.map(|u| Json(u)))
+}
+
+#[put("/game/<uuid>/tiles/<x>/<y>", data = "<tile>")]
+fn place_tile(games: State<Games>, uuid: UUID, x: i8, y: i8, tile: Json<Tile>) -> Option<Json<Tile>> {
+    with_game(games, uuid, |game| {
+        game.set_tile(x, y, tile.clone());
+    });
+    Some(tile)
 }
 
 struct UUID {
@@ -157,7 +175,7 @@ fn rocket() -> Result<rocket::Rocket, Error> {
         .manage(Meta::generate())
         .manage(Mutex::new(HashMap::<Uuid, Game>::new()))
         .mount("/", routes![meta, roll, new_game, get_game, join_game,
-                            get_player, start_game, get_tile])
+                            get_player, start_game, get_next_tile, get_tile, place_tile])
         .attach(cors)
         .register(catchers![not_found]))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,13 +124,12 @@ fn get_next_tile(games: State<Games>, uuid: UUID) -> Option<Json<Tile>> {
 }
 
 #[get("/game/<uuid>/tiles/<x>/<y>")]
-fn get_tile(games: State<Games>, uuid: UUID, x: i8, y: i8) -> Option<Option<Json<Tile>>> {
+fn get_tile(games: State<Games>, uuid: UUID, x: i8, y: i8) -> Option<Json<Option<Tile>>> {
     let mut tile: Option<Option<Tile>> = None;
     with_game(games, uuid, |game| {
         tile = Some(game.get_tile(x, y));
     });
-    // TODO(toby): This always results in a 404 if the tile is missing. Should be 200 with some result as long as the game ID is valid.
-    tile.map(|t| t.map(|u| Json(u)))
+    tile.map(|t| Json(t))
 }
 
 #[put("/game/<uuid>/tiles/<x>/<y>", data = "<tile>")]

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,13 +3,16 @@ use rand::thread_rng;
 use rand::Rng;
 use rand::seq::SliceRandom;
 
+use std::collections::HashMap;
+
 // complete record of the game that's stored on the server
 #[derive(Debug)]
 pub struct Game {
     pub description: GameDescription,
     pub players: Vec<Player>,
     pub turns: Vec<Turn>,
-    pub tileset: Vec<Tile>
+    pub tileset: Vec<Tile>,
+    tilemap: TileMap,
 }
 
 impl Game {
@@ -24,7 +27,8 @@ impl Game {
             description: GameDescription::default(),
             players: vec![],
             turns: vec![],
-            tileset: tiles // TODO: tileset
+            tileset: tiles, // TODO: tileset
+            tilemap: TileMap::new(),
         }
     }
 
@@ -47,6 +51,14 @@ impl Game {
         self.tileset.pop()
     }
 //    fn turn(&mut self) -> Turn {}
+
+    pub fn get_tile(&self, x: i8, y: i8) -> Option<Tile> {
+        self.tilemap.get_tile(x, y)
+    }
+
+    pub fn set_tile(&mut self, x: i8, y: i8, tile: Tile) {
+        self.tilemap.set_tile(x, y, tile);
+    }
 }
 
 // impl Default for everything
@@ -140,4 +152,52 @@ impl Character {
 #[derive(Debug)]
 pub struct Card {
     // TODO
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct TilePosition {
+    x: i8,
+    y: i8,
+}
+
+#[derive(Debug)]
+pub struct TileMap {
+    tiles: HashMap::<TilePosition, Tile>,
+}
+
+impl TileMap {
+    pub fn new() -> Self {
+        Self {
+            tiles: HashMap::<TilePosition, Tile>::new(),
+        }
+    }
+
+    pub fn get_tile(&self, x: i8, y: i8) -> Option<Tile> {
+        let pos = TilePosition { x, y };
+        self.tiles.get(&pos).map(|tile| tile.clone())
+
+    }
+
+    pub fn set_tile(&mut self, x: i8, y: i8, tile: Tile) {
+        let pos = TilePosition { x, y };
+        self.tiles.insert(pos, tile);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tile_map() {
+        let tileset = Tile::load_tiles();
+
+        let mut tile_map = TileMap::new();
+
+        assert_eq!(tile_map.get_tile(5, 8), None);
+
+        tile_map.set_tile(5, 8, tileset[1].clone());
+
+        assert_eq!(tile_map.get_tile(5, 8), Some(tileset[1].clone()));
+    }
 }


### PR DESCRIPTION
This PR adds two new endpoints for viewing and placing tiles on the map.

`GET /game/<uuid>/tiles/<x>/<y>`
Gets the current tile, if one exists, at the specified (x, y). 
- Valid values for both x and y are integers in the range [-128, 127] inclusive.
- Will return `200 OK` and a body of `null` if there is no tile.
- Will return the Tile JSON if one exists

`PUT /game/<uuid>/tiles/<x>/<y>`
Places a tile at the given position.
- Expects a full tile JSON in the request body.
- TODO:
   - Will replace any existing tile. That shouldn't be possible.
   - No validation that the current user actually has the tile to place. 
