### PR TITLE
Replace Move structs with an enum

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -10,19 +10,16 @@ pub enum GameState { WAITING, PLAYING, FINISHED }
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum PlayerState { WAITING, READY, ACTIVE }
 
+
 // Players send these to the server, which responds with Turns
 // all should have time and signature
-trait Move {}
-
-struct ReadyToStart{ name: String }
-struct PlaceTile{}
-struct DrawCard{}
-struct RollDice{}
-
-impl Move for ReadyToStart {}
-impl Move for PlaceTile {}
-impl Move for DrawCard {}
-impl Move for RollDice {}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum Move {
+    ReadyToStart{ name: String },
+    PlaceTile {},
+    DrawCard {},
+    RollDice {},
+}
 
 #[derive(Clone, Debug, Serialize)]
 pub struct GameDescription {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-use crate::api::{Etag, Href, Key, GameDescription, Player, GameState, PlayerState, PlayerUpdate, Tile};
+use crate::api::{Etag, Href, Key, GameDescription, Player, Move, GameState, PlayerState, PlayerUpdate, Tile};
 use rand::thread_rng;
 use rand::Rng;
 use rand::seq::SliceRandom;
@@ -67,6 +67,16 @@ impl Game {
     pub fn set_tile(&mut self, x: i8, y: i8, tile: Tile) {
         self.tilemap.set_tile(x, y, tile.id);
     }
+
+    pub fn apply(&mut self, action: Move) {
+        // TODO: Actually execute the moves
+        match action {
+            Move::ReadyToStart { name } => panic!("Move: ReadyToStart {}", name),
+            Move::RollDice {} => panic!("Move: RollDice"),
+            Move::DrawCard {} => panic!("Move: DrawCard"),
+            Move::PlaceTile {} => panic!("Move: PlaceTile"),
+        }
+    }
 }
 
 // impl Default for everything
@@ -83,11 +93,6 @@ pub struct Turn {
     etag: Etag,
     href: Href,
 }
-
-#[derive(Debug)]
-pub struct Move {
-}
-
 
 #[derive(Debug)]
 pub struct Decks {


### PR DESCRIPTION
Use a simple enum for moves to allow easy pattern matching.